### PR TITLE
Add lifeos-cli to General Purpose Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ These tools provide:
 - [tAI](https://github.com/bjarneo/tAI) - Terminal AI assistant that translates natural language to shell commands with interactive execution. Supports multiple providers (OpenAI, Google, Anthropic, Groq) with TUI setup and enhanced terminal UI.
 - [anthropic-cli](https://github.com/dvcrn/anthropic-cli) - Unofficial CLI for interacting with Anthropic's Claude API. Supports text and image messages (PNG, JPEG, PDF), various parameters (temperature, top-k, top-p), and can be integrated with other command-line tools.
 - [Grok CLI](https://grokcli.io/) - Conversational AI CLI tool for interacting with xAI's Grok models.
+- [lifeos-cli](https://github.com/liujuanjuan1984/lifeos-cli) - Terminal-native LifeOS for personal workflows, intentions, and habits with agent-friendly interface.
 
 ## AI Coding Assistants & Agents
 


### PR DESCRIPTION
Add [lifeos-cli](https://github.com/liujuanjuan1984/lifeos-cli) to the list. It is a terminal-native LifeOS providing structured context for agentic workflows.