### PR TITLE
Add agenttrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   - [Interactive Pair Programmers](#interactive-pair-programmers)
   - [Provider-Native Coding CLIs](#provider-native-coding-clis)
 - [Terminal Integration Tools](#terminal-integration-tools)
+  - [Agent Observability](#agent-observability)
   - [Shell Enhancements](#shell-enhancements)
   - [AI-Enhanced Terminals](#ai-enhanced-terminals)
 
@@ -82,6 +83,10 @@ These tools provide:
 - [GitHub Copilot CLI](https://github.com/github/copilot-cli) - The power of Copilot coding agent directly to your terminal.
 
 ## Terminal Integration Tools
+
+### Agent Observability
+
+- [agenttrace](https://github.com/luoyuctl/agenttrace) - Local-first TUI for AI coding-agent session logs, tracking cost, tokens, latency, tool failures, diffs, reports, and CI gates.
 
 ### Shell Enhancements
 


### PR DESCRIPTION
Adds agenttrace to the terminal tooling list.

agenttrace is a local-first TUI for observing AI coding agent sessions. It fits the terminal AI workflow scope because it helps developers inspect local Claude Code, Codex CLI, Gemini CLI, Aider, Cursor export, and similar session logs for cost, token usage, tool failures, latency, anomalies, health scores, diffs, and CI gates.

Package: https://github.com/luoyuctl/agenttrace