### PR TITLE
Add codex-profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ These tools provide:
 - [ShellGPT](https://github.com/TheR1D/shell_gpt) - ChatGPT integration for shell commands.
 - [zsh-ai](https://github.com/matheusml/zsh-ai) - AI-powered Zsh plugin.
 - [TmuxAI](https://github.com/alvinunreal/tmuxai) - AI-powered plugin for Tmux that integrates ChatGPT into your terminal multiplexer.
+- [codex-profiles](https://github.com/Ducksss/codex-profiles) - Launch Codex CLI and Desktop with isolated CODEX_HOME profiles for safe account switching.
 
 ### AI-Enhanced Terminals
 


### PR DESCRIPTION
## Summary

Adds `codex-profiles`, a small open-source helper for switching Codex CLI and Codex Desktop accounts with isolated `CODEX_HOME` profiles.

## Why

This fits the terminal AI workflow catalogue as a shell helper for running Codex with separated local account/profile state.

## Validation

- Ran `git diff --check`
- Added one README entry only
