### PR TITLE
Add Nanocoder (https://github.com/Nano-Collective/nanocoder)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ These tools provide:
 - [Qoder CLI](https://qoder.com/cli) - An AI coding companion for the terminal that assists developers with writing, debugging, and understanding code through natural language.
 - [LLxprt Code](https://github.com/vybestack/llxprt-code) - A specialized AI coding assistant designed to provide expert-level code explanations, debugging help, and generation.
 - [iFlow CLI](https://github.com/iflow-ai/iflow-cli) - An AI-driven CLI tool for automating development workflows and streamlining coding processes through intelligent assistance.
+- [Nanocoder](https://github.com/Nano-Collective/nanocoder) - A local-first, open-source coding agent that runs on your own models (Ollama, OpenRouter, or any OpenAI-compatible API), keeping your code on your machine.
 
 ### Provider-Native Coding CLIs
 


### PR DESCRIPTION
Adds [Nanocoder](https://github.com/Nano-Collective/nanocoder) to AI Coding Assistants & Agents > Interactive Pair Programmers.

**Why include it:** Nanocoder is a local-first, open-source coding agent for the terminal. You bring your own model (Ollama, OpenRouter, or any OpenAI-compatible API) and your code stays on your machine. It works interactively alongside you with tool confirmation, which fits the Interactive Pair Programmers category.

- Open source, documented, actively maintained (2k+ stars)
- Added at the bottom of the category per CONTRIBUTING
- Format: capital start, period end, GitHub link
- I agree to abide by the project's Code of Conduct