### PR TITLE
Add DvalinCode (governance-focused terminal coding agent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ These tools provide:
 - [Cline CLI](https://docs.cline.bot/cline-cli/getting-started) - An autonomous coding agent that can edit files, run terminal commands, and execute complex software development tasks directly from the CLI.
 - [Factory Droid](https://factory.ai/product/cli) - An autonomous software engineering system designed to handle backlog tasks, refactoring, and feature development with minimal human intervention.
 - [Goose CLI](https://github.com/block/goose) - An open-source developer agent from Block that automates engineering tasks, manages developer workflows, and executes complex instructions.
+- [DvalinCode](https://github.com/arthurpanhku/dvalincode) - Local-first, provider-neutral coding agent built for governance: an org policy engine, enforced network egress, and a tamper-evident audit trail. Three modes (Chat/Cowork/Code), works with any OpenAI-compatible endpoint.
 
 ### Interactive Pair Programmers
 


### PR DESCRIPTION
Adds **DvalinCode** to _AI Coding Assistants & Agents → Autonomous Software Engineers_ (appended at the bottom of the category per CONTRIBUTING). Disclosure: I maintain DvalinCode.

[DvalinCode](https://github.com/arthurpanhku/dvalincode) is a local-first, provider-neutral terminal coding agent (Chat/Cowork/Code modes) whose differentiator is governance:

- org policy engine (machine + repo, narrowing-only)
- enforced network egress — per-request provider checks plus OS-sandboxed subprocesses (macOS `sandbox-exec`, Linux Bubblewrap), failing closed where isolation can't be enforced
- tamper-evident, hash-chained audit trail; `dvalincode trust` reports the install's real enforcement posture

Works with any OpenAI-compatible endpoint (DeepSeek, OpenAI, Claude via OpenRouter, Groq, Ollama). Zero runtime deps, MIT. Tested and documented; checked for duplicates (not currently listed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)