### PR TITLE
Add Orca to Autonomous Software Engineers

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ These tools provide:
 - [Cline CLI](https://docs.cline.bot/cline-cli/getting-started) - An autonomous coding agent that can edit files, run terminal commands, and execute complex software development tasks directly from the CLI.
 - [Factory Droid](https://factory.ai/product/cli) - An autonomous software engineering system designed to handle backlog tasks, refactoring, and feature development with minimal human intervention.
 - [Goose CLI](https://github.com/block/goose) - An open-source developer agent from Block that automates engineering tasks, manages developer workflows, and executes complex instructions.
+- [Orca](https://github.com/echoVic/blade-deepseek) - A DeepSeek-native terminal coding agent in Rust with OS-level sandboxing, persistent goal mode with stall detection, background tasks, and verification gates.
 
 ### Interactive Pair Programmers
 


### PR DESCRIPTION
Adds [Orca](https://github.com/echoVic/blade-deepseek) — an open-source DeepSeek-native terminal coding agent built in Rust (single binary, MIT).

Fits the *Autonomous Software Engineers* category: multi-step agent loop with persistent goal mode (stall detection instead of a fixed turn ceiling), OS-level sandboxing (Seatbelt / bubblewrap / Landlock+seccomp), background tasks, and verification gates that require a real command to pass before a task counts as done. Entry follows the existing format and is appended to the end of the section.