### PR TITLE
Add lucinate: multi-backend terminal AI chat client

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ These tools provide:
 - [tAI](https://github.com/bjarneo/tAI) - Terminal AI assistant that translates natural language to shell commands with interactive execution. Supports multiple providers (OpenAI, Google, Anthropic, Groq) with TUI setup and enhanced terminal UI.
 - [anthropic-cli](https://github.com/dvcrn/anthropic-cli) - Unofficial CLI for interacting with Anthropic's Claude API. Supports text and image messages (PNG, JPEG, PDF), various parameters (temperature, top-k, top-p), and can be integrated with other command-line tools.
 - [Grok CLI](https://grokcli.io/) - Conversational AI CLI tool for interacting with xAI's Grok models.
+- [lucinate](https://github.com/lucinate-ai/lucinate) - A multi-backend terminal AI chat client for OpenClaw, Hermes, Ollama, and OpenAI-compatible APIs.
 
 ## AI Coding Assistants & Agents
 


### PR DESCRIPTION
### Add [lucinate](https://github.com/lucinate-ai/lucinate)

A terminal-native AI chat client that supports OpenClaw, Hermes Agent, Ollama, and any OpenAI-compatible backend — with routines, multi-agent switching, and streaming responses, all in the TUI.

**Why it fits this list:** lucinate is a general-purpose chat & shell utility, sitting alongside the other tools in this section. It connects to OpenClaw, Hermes, Ollama, vLLM, LM Studio, and OpenAI proper — all from a single TUI — and features reusable prompt routines, inline tool call cards, and local agent skills.

**Contribution guidelines followed:**
- Added to the bottom of "General Purpose Chat & Shell Utilities" as specified
- Description starts with a capital, ends with a full stop
- Links to the GitHub repo

Thanks for curating this list!