### PR TITLE
Add SandBase CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ These tools provide:
 - [tAI](https://github.com/bjarneo/tAI) - Terminal AI assistant that translates natural language to shell commands with interactive execution. Supports multiple providers (OpenAI, Google, Anthropic, Groq) with TUI setup and enhanced terminal UI.
 - [anthropic-cli](https://github.com/dvcrn/anthropic-cli) - Unofficial CLI for interacting with Anthropic's Claude API. Supports text and image messages (PNG, JPEG, PDF), various parameters (temperature, top-k, top-p), and can be integrated with other command-line tools.
 - [Grok CLI](https://grokcli.io/) - Conversational AI CLI tool for interacting with xAI's Grok models.
+- [SandBase](https://github.com/sandbaseai/cli) - Connect AI clients to 2,000+ models, API tools, and cloud sandboxes.
 
 ## AI Coding Assistants & Agents
 


### PR DESCRIPTION
## Why include SandBase

[SandBase CLI](https://github.com/sandbaseai/cli) is an open-source, documented terminal tool for connecting supported AI clients to SandBase through an ownership-aware MCP bridge. It fits **General Purpose Chat & Shell Utilities** because it provides client discovery, zero-change JSON catalog output, setup diagnostics, and a terminal-managed bridge to 2,000+ models, API tools, and cloud sandboxes.

## Verification

- Published npm package: `@sandbaseai/cli` v0.1.14
- Apache-2.0 licensed source
- GitHub Actions pass 150 tests and package auditing
- Documentation is available in English, Chinese, Japanese, Korean, Spanish, French, German, and Portuguese
- Entry follows the requested format and is appended to the category

## Disclosure

Submitted from the official `sandbaseai` organization fork.