### PR TITLE
Add Kolega Code to Autonomous Software Engineers

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ These tools provide:
 - [Cline CLI](https://docs.cline.bot/cline-cli/getting-started) - An autonomous coding agent that can edit files, run terminal commands, and execute complex software development tasks directly from the CLI.
 - [Factory Droid](https://factory.ai/product/cli) - An autonomous software engineering system designed to handle backlog tasks, refactoring, and feature development with minimal human intervention.
 - [Goose CLI](https://github.com/block/goose) - An open-source developer agent from Block that automates engineering tasks, manages developer workflows, and executes complex instructions.
+- [Kolega Code](https://github.com/kolega-ai/kolega-code) - Open-source terminal coding agent where the model writes its own multi-agent workflows (Gigacode), provider-agnostic with MCP support.
 
 ### Interactive Pair Programmers
 


### PR DESCRIPTION
# Add Kolega Code to Autonomous Software Engineers

Adds Kolega Code to the Autonomous Software Engineers section, at the bottom of the category per the contribution guidelines.

Repo: https://github.com/kolega-ai/kolega-code

Why it should be included: it is an open-source terminal coding agent that plans and executes multi-step development work with high autonomy. For repo-wide tasks the model writes a Python orchestration program (Gigacode) that fans out to parallel sub-agents under enforced concurrency and budget caps. Provider-agnostic with MCP support, local-first state, and a Textual TUI.
